### PR TITLE
Add image uploade feature using blobstore based on week 3 walkthrough

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -19,11 +19,13 @@ public final class Comment{
     private final String author;
     private final String organization;
     private final long timestamp;
+    private final String imageUrl;
 
-    public Comment(String comment, String author, String organization, long timestamp){
+    public Comment(String comment, String author, String organization, long timestamp, String imageUrl){
         this.comment = comment;
         this.author = author;
         this.organization = organization;
         this.timestamp = timestamp;
+        this.imageUrl = imageUrl;
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
@@ -1,0 +1,31 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * When the fetch() function requests the /blobstore-upload-url URL, the content of the response is
+ * the URL that allows a user to upload a file to Blobstore.
+ */
+@WebServlet("/blobstore-upload-url")
+public class BlobstoreUploadUrlServlet extends HttpServlet {
+
+  private static BlobstoreService blobstoreService;
+
+  @Override
+  public void init(){
+    blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+  }
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String uploadUrl = blobstoreService.createUploadUrl("/data-post");
+
+    response.setContentType("text/html");
+    response.getWriter().println(uploadUrl);
+  }
+} 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataGetServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataGetServlet.java
@@ -38,8 +38,8 @@ public class DataGetServlet extends HttpServlet {
   private static Query query;
   @Override
   public void init(){
-      datastore = DatastoreServiceFactory.getDatastoreService();
-      query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
   }
   /* get function that returns the comments in JSON format */
   @Override
@@ -52,8 +52,9 @@ public class DataGetServlet extends HttpServlet {
       String author = (String) entity.getProperty("author");
       String organization = (String) entity.getProperty("organization");
       long timestamp = (long) entity.getProperty("timestamp");
+      String imageUrl = (String) entity.getProperty("imageUrl");
 
-      Comment finalComment = new Comment(comment, author, organization, timestamp);
+      Comment finalComment = new Comment(comment, author, organization, timestamp, imageUrl);
       comments.add(finalComment);
     }
     String json = convertToJson(comments);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataPostServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataPostServlet.java
@@ -46,11 +46,12 @@ public class DataPostServlet extends HttpServlet {
 
   private static DatastoreService datastore;
   private static BlobstoreService blobstoreService;
+  private static ImagesService imagesService;
   @Override
   public void init(){
     datastore = DatastoreServiceFactory.getDatastoreService();
     blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-
+    imagesService = ImagesServiceFactory.getImagesService();
   }
 
   /*post function to read input of the form and add the comment to the database*/
@@ -96,8 +97,6 @@ public class DataPostServlet extends HttpServlet {
         return null;
     }
 
-    // Use ImagesService to get a URL that points to the uploaded file.
-    ImagesService imagesService = ImagesServiceFactory.getImagesService();
     ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
     String url = imagesService.getServingUrl(options);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataPostServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataPostServlet.java
@@ -30,14 +30,27 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.appengine.api.blobstore.BlobInfo;
+import com.google.appengine.api.blobstore.BlobInfoFactory;
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.images.ImagesService;
+import com.google.appengine.api.images.ImagesServiceFactory;
+import com.google.appengine.api.images.ServingUrlOptions;
+import java.util.Map;
+
 
 @WebServlet("/data-post")
 public class DataPostServlet extends HttpServlet {
 
   private static DatastoreService datastore;
+  private static BlobstoreService blobstoreService;
   @Override
   public void init(){
-      datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+
   }
 
   /*post function to read input of the form and add the comment to the database*/
@@ -49,16 +62,51 @@ public class DataPostServlet extends HttpServlet {
     String author = request.getParameter("author");
     String organization = request.getParameter("organization");
     long timestamp = System.currentTimeMillis();
+    String imageUrl = getUploadedFileUrl(request, "image");
 
     Entity taskEntity = new Entity("Comment");
     taskEntity.setProperty("comment", comment);
     taskEntity.setProperty("author", author);
     taskEntity.setProperty("organization", organization);
     taskEntity.setProperty("timestamp", timestamp);
+    taskEntity.setProperty("imageUrl",imageUrl);
 
     datastore.put(taskEntity);
 
     response.sendRedirect("/index.html#comments");
+  }
+
+/** Returns a URL that points to the uploaded file, or null if the user didn't upload a file. */
+  private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
+    Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
+    List<BlobKey> blobKeys = blobs.get(formInputElementName);
+
+    // User submitted form without selecting a file, so we can't get a URL. (dev server)
+    if (blobKeys == null || blobKeys.isEmpty()) {
+        return null;
+    }
+
+    // Our form only contains a single file input, so get the first index.
+    BlobKey blobKey = blobKeys.get(0);
+
+    // User submitted form without selecting a file, so we can't get a URL. (live server)
+    BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
+    if (blobInfo.getSize() == 0) {
+        blobstoreService.delete(blobKey);
+        return null;
+    }
+
+    // Use ImagesService to get a URL that points to the uploaded file.
+    ImagesService imagesService = ImagesServiceFactory.getImagesService();
+    ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
+    String url = imagesService.getServingUrl(options);
+
+    // GCS's localhost preview is not actually on localhost,
+    // so make the URL relative to the current domain.
+    if(url.startsWith("http://localhost:8080/")){
+        url = url.replace("http://localhost:8080/", "/");
+    }
+    return url;
   }
 
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -16,7 +16,7 @@
         <!-- Material Design Bootstrap -->
         <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.19.1/css/mdb.min.css" rel="stylesheet">
     </head>
-    <body id="page-top" onload="addCommentsToPortfolio()">
+    <body id="page-top" onload="addCommentsToPortfolio(); fetchBlobstoreUrlAndShowForm();">
         <!-- Navigation Bar-->
         <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
             <div class="container">
@@ -697,7 +697,7 @@
                                 </button>
                             </div>
                         <!--Form to take comment input-->
-                            <form action = "/data-post" method = "POST" id="comment-form">
+                            <form id = "comment-form" method = "POST" enctype="multipart/form-data">
                                 <div class="modal-body mx-3">
                                     <div class="md-form mb-5">
                                         <i class="fas fa-address-book prefix grey-text"></i>
@@ -712,6 +712,10 @@
                                     <div class="md-form mb-5">
                                         <i class="fas fa-comment-dots prefix grey-text"></i>
                                         <textarea type="text" name= "comment" id="comment" class="form-control validate" required></textarea>
+                                    </div>
+                                    <div class="md-form mb-5">
+                                        <i class="fas fa-camera prefix grey-text"></i>
+                                        <input type="file" name="image" accept="image/gif, image/jpeg, image/png, image/jpg">
                                     </div>
                                 </div>
                             </form>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -98,6 +98,11 @@ function getCommentData(comment){
     var blockQuote = document.createElement("blockquote");
     blockQuote.className = "blockquote mb-0";
     blockQuote.appendChild(getCommentPara(comment));
+    if(comment.imageUrl){
+        var img = document.createElement("img"); 
+        img.src =  comment.imageUrl;
+        blockQuote.appendChild(img);
+    }
     blockQuote.appendChild(getCommentFooter(comment));
     return blockQuote;
 }
@@ -123,4 +128,15 @@ function addCommentsToPortfolio() {
     }
 
   });
+}
+
+function fetchBlobstoreUrlAndShowForm() {
+  fetch('/blobstore-upload-url')
+      .then((response) => {
+        return response.text();
+      })
+      .then((uploadUrl) => {
+        const messageForm = document.getElementById('comment-form');
+        messageForm.action = uploadUrl;
+      });
 }


### PR DESCRIPTION
I have added feature to upload image along with the comment based on week 3 walkthrough. I have used Blobstore library which stores the image and returns a URL which is then stored in the Comment database. Adding image to a comment is kept optional. UI looks as follows:
![imagecomment1](https://user-images.githubusercontent.com/36463678/87863316-881b4080-c977-11ea-9d01-d18be18d2b7c.png)
![imagecomment2](https://user-images.githubusercontent.com/36463678/87863317-8a7d9a80-c977-11ea-94c2-425e298920c9.png)
